### PR TITLE
[FIX] Instant Search 에러 수정

### DIFF
--- a/app/src/main/java/com/preonboarding/moviereview/presentation/ui/search/SearchFragment.kt
+++ b/app/src/main/java/com/preonboarding/moviereview/presentation/ui/search/SearchFragment.kt
@@ -52,10 +52,8 @@ class SearchFragment : BaseFragment<FragmentSearchBinding>(R.layout.fragment_sea
                     .debounce(300)
                     .filter { query ->
                         if (query.isBlank()) {
-                            viewModel.searchMovie("")
-                                .collectLatest {
-                                    pagingAdapter.submitData(it)
-                                }
+                            // 비어있는 뷰 처리
+                            binding.tvEmptyQuery.visibility = View.VISIBLE
                             return@filter false
                         } else {
                             return@filter true
@@ -66,6 +64,7 @@ class SearchFragment : BaseFragment<FragmentSearchBinding>(R.layout.fragment_sea
                         viewModel.searchMovie(query)
                     }
                     .collectLatest {
+                        binding.tvEmptyQuery.visibility = View.GONE
                         pagingAdapter.submitData(it)
                     }
             }

--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -51,5 +51,16 @@
             app:layout_constraintTop_toBottomOf="@id/abl_search"
             tools:listitem="@layout/item_search_result" />
 
+        <TextView
+            android:id="@+id/tv_empty_query"
+            style="@style/Body18.Grey"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="영화 제목을 입력하세요."
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/abl_search" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>


### PR DESCRIPTION
* query가 비어있을 경우 전체 목록 띄우고 이후 이벤트 발생 시 수신 못하는 이슈
  * empty view 띄우는 것으로 우선 대체
